### PR TITLE
Refactor colours to palette and fix SMDU hover colour

### DIFF
--- a/src/components/WorkSection.tsx
+++ b/src/components/WorkSection.tsx
@@ -8,7 +8,7 @@ export default function WorkSection() {
 
       {/* Liminal Notes (Flagship) */}
       <article className={`${styles.projectCard} cursor-pointer`}>
-        <span className="text-xs uppercase tracking-[0.1em] text-[#ffaa40] font-bold mb-4 inline-block border border-[rgba(255,170,64,0.3)] px-[10px] py-1 rounded">
+        <span className="text-xs uppercase tracking-[0.1em] text-[var(--accent-orange)] font-bold mb-4 inline-block border border-[var(--accent-orange)] px-[10px] py-1 rounded">
           Knowledge Base
         </span>
         <h3 className="text-[2.5rem] mb-4 text-white">Liminal Notes</h3>
@@ -18,7 +18,7 @@ export default function WorkSection() {
         </p>
         <a
           href="https://github.com/ScottMorris/liminal-notes"
-          className="inline-flex items-center gap-[10px] font-semibold text-white bg-[rgba(255,255,255,0.1)] px-6 py-3 rounded-[30px] transition-all duration-300 hover:bg-[#ffaa40] hover:text-black hover:translate-x-[5px]"
+          className="inline-flex items-center gap-[10px] font-semibold text-white bg-[rgba(255,255,255,0.1)] px-6 py-3 rounded-[30px] transition-all duration-300 hover:bg-[var(--accent-orange)] hover:text-black hover:translate-x-[5px]"
         >
           View Project →
         </a>
@@ -26,8 +26,8 @@ export default function WorkSection() {
 
       {/* Experiments */}
       <div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-8">
-        <article className="bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.1)] p-8 rounded-2xl transition-all duration-300 hover:bg-[rgba(255,255,255,0.05)] hover:border-[#f43f5e]">
-          <span className="text-xs uppercase tracking-[0.1em] text-[#a78bfa] font-bold mb-4 inline-block border border-[#a78bfa] px-[10px] py-1 rounded">
+        <article className="bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.1)] p-8 rounded-2xl transition-all duration-300 hover:bg-[rgba(255,255,255,0.05)] hover:border-[var(--accent-purple)]">
+          <span className="text-xs uppercase tracking-[0.1em] text-[var(--accent-purple)] font-bold mb-4 inline-block border border-[var(--accent-purple)] px-[10px] py-1 rounded">
             CLI Utility
           </span>
           <h3 className="mt-2 text-white text-[2rem] mb-4">SMDU</h3>
@@ -36,14 +36,14 @@ export default function WorkSection() {
           </p>
           <a
             href="https://github.com/ScottMorris/smdu/"
-            className="text-[0.9rem] text-white border-b border-[#a78bfa] pb-[2px]"
+            className="text-[0.9rem] text-white border-b border-[var(--accent-purple)] pb-[2px]"
           >
             View Source
           </a>
         </article>
 
-        <article className="bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.1)] p-8 rounded-2xl transition-all duration-300 hover:bg-[rgba(255,255,255,0.05)] hover:border-[#22d3ee]">
-          <span className="text-xs uppercase tracking-[0.1em] text-[#22d3ee] font-bold mb-4 inline-block border border-[#22d3ee] px-[10px] py-1 rounded">
+        <article className="bg-[rgba(255,255,255,0.02)] border border-[rgba(255,255,255,0.1)] p-8 rounded-2xl transition-all duration-300 hover:bg-[rgba(255,255,255,0.05)] hover:border-[var(--accent-cyan)]">
+          <span className="text-xs uppercase tracking-[0.1em] text-[var(--accent-cyan)] font-bold mb-4 inline-block border border-[var(--accent-cyan)] px-[10px] py-1 rounded">
             Simulation
           </span>
           <h3 className="mt-2 text-white text-[2rem] mb-4">City Sim 1000</h3>
@@ -52,7 +52,7 @@ export default function WorkSection() {
           </p>
           <a
             href="https://github.com/ScottMorris/city-sim-1000"
-            className="text-[0.9rem] text-white border-b border-[#22d3ee] pb-[2px]"
+            className="text-[0.9rem] text-white border-b border-[var(--accent-cyan)] pb-[2px]"
           >
             View Project
           </a>


### PR DESCRIPTION
## Description
This PR refactors the [WorkSection](cci:1://file:///home/scott/source/liminalhq/liminal-hq.github.io/src/components/WorkSection.tsx:3:0-62:1) component to use the shared CSS variable colour palette and fixes a visual inconsistency with the SMDU project card.

## Changes
- **Refactor**: Replaced hardcoded hex colour values in [WorkSection.tsx](cci:7://file:///home/scott/source/liminalhq/liminal-hq.github.io/src/components/WorkSection.tsx:0:0-0:0) with semantic CSS variables defined in [globals.css](cci:7://file:///home/scott/source/liminalhq/liminal-hq.github.io/src/app/globals.css:0:0-0:0) (e.g., `var(--accent-orange)`, `var(--accent-purple)`).
- **Bug Fix**: Updated the SMDU card hover border colour from pink (`#f43f5e`) to **purple** (`var(--accent-purple)`) to correctly match its "CLI Utility" badge colour.