### PR TITLE
Update README with Liminal HQ branding and project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ An independent studio building local-first applications.
 - **[City Sim 1000](https://github.com/ScottMorris/city-sim-1000)** – Low-poly city simulation in the browser.
 - **[SMDU](https://github.com/ScottMorris/smdu)** – Terminal disk usage analyser.
 
-## Architecture
+## Site Architecture
 
-Built with modern web standards:
+This portfolio is built with modern web standards:
 
 - **Next.js 16** (App Router, Static Export)
 - **React 19**

--- a/README.md
+++ b/README.md
@@ -1,36 +1,32 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Liminal HQ
 
-## Getting Started
+**Digital tools for the spaces in between.**
+An independent studio building local-first applications.
 
-First, run the development server:
+## Projects
+
+- **[Liminal Notes](https://github.com/ScottMorris/liminal-notes)** – Local-first, Markdown-based note-taking.
+- **[City Sim 1000](https://github.com/ScottMorris/city-sim-1000)** – Low-poly city simulation in the browser.
+- **[SMDU](https://github.com/ScottMorris/smdu)** – Terminal disk usage analyser.
+
+## Architecture
+
+Built with modern web standards:
+
+- **Next.js 16** (App Router, Static Export)
+- **React 19**
+- **Tailwind CSS 4**
+- **TypeScript**
+
+## Development
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) to view locally.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Deployment
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Automated via **GitHub Actions** to GitHub Pages. Pushing to `main` builds and deploys the `out/` directory.


### PR DESCRIPTION
## Description

This PR updates the `README.md` to replace the generic Next.js template with a custom README for the Liminal HQ portfolio site.

Changes include:
- **Branding**: Updated title and description to match the "Independent Digital Studio" identity.
- **Projects**: Added a "Projects" section linking to key repositories (Liminal Notes, City Sim 1000, SMDU) to unify the portfolio.
- **Architecture**: Clarified the "Site Architecture" section to specify the tech stack for this specific project (Next.js 16, React 19, Tailwind 4).
- **Workflow**: Added clear "Development" instructions and documented the GitHub Pages deployment workflow.

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Verified that external links to projects are correct.
- [x] Verified `pnpm` commands match `package.json` scripts.
- [x] Verified markdown formatting in local preview.