### PR TITLE
Add site metadata, sitemap, and robots routes

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,6 +9,9 @@ import {
   getPostBySlug,
   markdownToHtml,
 } from "@/lib/blog";
+import { getSiteUrl } from "@/lib/site";
+
+const siteUrl = getSiteUrl();
 
 interface BlogPostPageProps {
   params: Promise<{ slug: string }>;
@@ -32,6 +35,23 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
   return {
     title: `${post.title} | Liminal HQ`,
     description: post.excerpt,
+    alternates: {
+      canonical: `/blog/${post.slug}`,
+    },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt,
+      url: `${siteUrl}/blog/${post.slug}`,
+      siteName: "Liminal HQ",
+      type: "article",
+      publishedTime: `${post.date}T00:00:00.000Z`,
+      tags: post.tags,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.excerpt,
+    },
   };
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,10 +3,29 @@ import Link from "next/link";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { formatPostDate, getAllPostsMeta } from "@/lib/blog";
+import { getSiteUrl } from "@/lib/site";
+
+const siteUrl = getSiteUrl();
+const blogUrl = `${siteUrl}/blog`;
 
 export const metadata: Metadata = {
   title: "Blog | Liminal HQ",
   description: "Technical writing and studio notes from Liminal HQ.",
+  alternates: {
+    canonical: "/blog",
+  },
+  openGraph: {
+    title: "Blog | Liminal HQ",
+    description: "Technical writing and studio notes from Liminal HQ.",
+    url: blogUrl,
+    siteName: "Liminal HQ",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Blog | Liminal HQ",
+    description: "Technical writing and studio notes from Liminal HQ.",
+  },
 };
 
 export default async function BlogIndexPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, Space_Grotesk } from "next/font/google";
 import BackToTopButton from "@/components/BackToTopButton";
+import { getSiteUrl } from "@/lib/site";
 import "./globals.css";
 
 const inter = Inter({
@@ -15,9 +16,24 @@ const spaceGrotesk = Space_Grotesk({
   display: "swap",
 });
 
+const siteUrl = getSiteUrl();
+
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: "Liminal HQ | Independent Digital Studio",
   description: "Digital tools for the spaces in between. An independent studio building local-first applications.",
+  openGraph: {
+    title: "Liminal HQ | Independent Digital Studio",
+    description: "Digital tools for the spaces in between. An independent studio building local-first applications.",
+    url: siteUrl,
+    siteName: "Liminal HQ",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Liminal HQ | Independent Digital Studio",
+    description: "Digital tools for the spaces in between. An independent studio building local-first applications.",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import type { MetadataRoute } from "next";
+import { getAllPostsMeta } from "@/lib/blog";
+import { getSiteUrl } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const siteUrl = getSiteUrl();
+  const posts = await getAllPostsMeta();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: `${siteUrl}/`,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/blog`,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+  ];
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${siteUrl}/blog/${post.slug}`,
+    lastModified: new Date(`${post.date}T00:00:00.000Z`),
+    changeFrequency: "monthly",
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...postRoutes];
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,11 @@
+const FALLBACK_SITE_URL = "https://liminalhq.ca";
+
+export function getSiteUrl(): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? process.env.SITE_URL;
+
+  if (!siteUrl || siteUrl.trim().length === 0) {
+    return FALLBACK_SITE_URL;
+  }
+
+  return siteUrl.replace(/\/$/, "");
+}


### PR DESCRIPTION
## Summary
- add shared site URL helper for consistent absolute metadata URLs
- add site-level metadata defaults (Open Graph + Twitter) in `layout`
- add blog index metadata (canonical, Open Graph, Twitter)
- add per-post metadata (canonical, article Open Graph fields, Twitter)
- add static metadata routes for `sitemap.xml` and `robots.txt`

## Validation
- `npx -y pnpm build`
  - verifies static export succeeds
  - confirms `/robots.txt` and `/sitemap.xml` are generated
