### PR TITLE
Add Flow to selected work

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,7 @@ html {
   --accent-pink: #f43f5e;
   --accent-purple: #a78bfa;
   --accent-cyan: #22d3ee;
+  --accent-blue: #60a5fa;
 
   /* Complex Gradients */
   --gradient-brand: linear-gradient(

--- a/src/components/work-section-data.ts
+++ b/src/components/work-section-data.ts
@@ -19,6 +19,15 @@ export const selectedWork: ProjectCard[] = [
     primaryCta: "Visit Site →",
   },
   {
+    label: "Working Memory",
+    accentColour: "var(--accent-blue)",
+    title: "Flow",
+    description:
+      "Local-first, terminal-native working memory for the shell. Track active threads, branch tangents, and keep context close while you work.",
+    repositoryUrl: "https://github.com/liminal-hq/flow",
+    primaryCta: "GitHub",
+  },
+  {
     label: "Knowledge Base",
     accentColour: "var(--accent-purple)",
     title: "Liminal Notes",


### PR DESCRIPTION
## Summary

- add Flow to the Selected Work section on the homepage
- link the card to the public GitHub repository
- add a blue accent token so the new card feels distinct within the existing palette

## Testing

- `/home/scott/.nvm/versions/node/v22.21.1/bin/pnpm lint`