### PR TITLE
Feature SMDU as the lead experiments card

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ We build software that feels more human without becoming less powerful.
 - **[Liminal Notes](https://github.com/ScottMorris/liminal-notes)** – Local-first, Markdown-based note-taking.
 - **[Flow](https://github.com/liminal-hq/flow)** – Calm, local-first focus sessions for intentional deep work.
 - **[City Sim 1000](https://github.com/ScottMorris/city-sim-1000)** – Low-poly city simulation in the browser.
+- **[Emoji Nook](https://github.com/liminal-hq/emoji-nook)** – Native Linux emoji picker for GNOME, KDE, and other desktop environments.
 - **[SMDU](https://github.com/ScottMorris/smdu)** – Terminal disk usage analyser.
 - **[Coherence Chat Exporter](https://github.com/liminal-hq/coherence-chat-exporter)** – CLI for archiving AI conversations into organised, tagged Markdown across providers.
 - **[Keep Note Converter](https://github.com/ScottMorris/keep-note-converter)** – Installable Next.js PWA that converts pasted rich text into Google Keep-compatible markup.

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties } from "react";
+import styles from "./WorkSection.module.css";
+import {
+  getPrimaryProjectUrl,
+  getProjectAccentStyles,
+  getProjectCardCssVariables,
+  type ProjectCard,
+} from "./work-section-data";
+
+interface FeaturedProjectCardProps {
+  project: ProjectCard;
+  headingLevel: "h3" | "h4";
+}
+
+export default function FeaturedProjectCard({ project, headingLevel: Heading }: FeaturedProjectCardProps) {
+  const accent = getProjectAccentStyles(project.accentColour);
+  const primaryUrl = getPrimaryProjectUrl(project);
+  const ctaLabel = project.primaryCta ?? (project.siteUrl ? "Visit Site" : "View Source");
+
+  return (
+    <article
+      className={`${styles.projectCard} group relative cursor-pointer`}
+      style={getProjectCardCssVariables(project.accentColour) as CSSProperties}
+    >
+      <a
+        href={primaryUrl}
+        className="absolute inset-0 z-10 rounded-[20px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--project-accent)] focus-visible:outline-offset-[-3px]"
+        aria-label={`Open ${project.title}`}
+        target="_blank"
+        rel="noreferrer"
+      ></a>
+
+      <div className="relative z-0">
+        <span
+          className="mb-4 inline-block rounded border px-[10px] py-1 text-xs font-bold uppercase tracking-[0.1em]"
+          style={accent.badge}
+        >
+          {project.label}
+        </span>
+        <Heading className="mb-4 text-[2rem] text-white md:text-[2.5rem]">{project.title}</Heading>
+        <p className="mb-10 max-w-[650px] text-base text-[var(--text-muted)] md:text-[1.15rem]">
+          {project.description}
+        </p>
+
+        <div className="flex flex-wrap items-center gap-5">
+          <span className="inline-flex items-center gap-[10px] rounded-[30px] bg-[rgba(255,255,255,0.1)] px-6 py-3 font-semibold text-white transition-all duration-300 group-hover:translate-x-[5px] group-hover:bg-[var(--project-accent)] group-hover:text-black">
+            {ctaLabel}
+          </span>
+          {project.siteUrl ? (
+            <a
+              href={project.repositoryUrl}
+              className="relative z-20 border-b border-[var(--project-accent)] pb-[2px] text-[0.9rem] text-white"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/WorkSection.module.css
+++ b/src/components/WorkSection.module.css
@@ -15,7 +15,8 @@
 
 .projectCard:hover {
   border-color: transparent;
-  box-shadow: 0 0 0 1px rgba(255, 170, 64, 0.5), 0 20px 50px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--project-accent, var(--accent-orange)) 50%, transparent),
+    0 20px 50px rgba(0, 0, 0, 0.4);
 }
 
 .projectCard::before {
@@ -27,7 +28,7 @@
   height: 400px;
   background: radial-gradient(
     circle,
-    rgba(255, 170, 64, 0.15) 0%,
+    color-mix(in srgb, var(--project-accent, var(--accent-orange)) 15%, transparent) 0%,
     transparent 70%
   );
   opacity: 0.5;

--- a/src/components/WorkSection.tsx
+++ b/src/components/WorkSection.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import styles from "./WorkSection.module.css";
+import FeaturedProjectCard from "./FeaturedProjectCard";
 import {
   experiments,
   getPrimaryProjectUrl,
@@ -10,54 +10,13 @@ import {
 
 export default function WorkSection() {
   const [flagship, ...supportingSelectedWork] = selectedWork;
-  const flagshipAccent = getProjectAccentStyles(flagship.accentColour);
-  const flagshipPrimaryUrl = getPrimaryProjectUrl(flagship);
   const [leadExperiment, ...supportingExperiments] = experiments;
-  const leadExperimentAccent = getProjectAccentStyles(leadExperiment.accentColour);
-  const leadExperimentPrimaryUrl = getPrimaryProjectUrl(leadExperiment);
 
   return (
     <section id="work" className="py-16 md:py-20">
       <h2 className="mb-8 text-[1.75rem] font-semibold text-white md:text-[2rem]">Selected Work</h2>
 
-      <article className={`${styles.projectCard} group relative cursor-pointer`}>
-        <a
-          href={flagshipPrimaryUrl}
-          className="absolute inset-0 z-10 rounded-[20px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-orange)] focus-visible:outline-offset-[-3px]"
-          aria-label={`Open ${flagship.title}`}
-          target="_blank"
-          rel="noreferrer"
-        ></a>
-
-        <div className="relative z-0">
-          <span
-            className="mb-4 inline-block rounded border px-[10px] py-1 text-xs font-bold uppercase tracking-[0.1em]"
-            style={flagshipAccent.badge}
-          >
-            {flagship.label}
-          </span>
-          <h3 className="mb-4 text-[2rem] text-white md:text-[2.5rem]">{flagship.title}</h3>
-          <p className="mb-10 max-w-[650px] text-base text-[var(--text-muted)] md:text-[1.15rem]">
-            {flagship.description}
-          </p>
-
-          <div className="flex flex-wrap items-center gap-5">
-            <span className="inline-flex items-center gap-[10px] rounded-[30px] bg-[rgba(255,255,255,0.1)] px-6 py-3 font-semibold text-white transition-all duration-300 group-hover:translate-x-[5px] group-hover:bg-[var(--accent-orange)] group-hover:text-black">
-              {flagship.primaryCta ?? "View Project"}
-            </span>
-            {flagship.siteUrl ? (
-              <a
-                href={flagship.repositoryUrl}
-                className="relative z-20 border-b border-[var(--accent-orange)] pb-[2px] text-[0.9rem] text-white"
-                target="_blank"
-                rel="noreferrer"
-              >
-                GitHub
-              </a>
-            ) : null}
-          </div>
-        </div>
-      </article>
+      <FeaturedProjectCard project={flagship} headingLevel="h3" />
 
       <div className="mb-12 grid grid-cols-1 gap-6 md:grid-cols-[repeat(auto-fit,minmax(280px,1fr))] md:gap-8">
         {supportingSelectedWork.map((project) => {
@@ -110,44 +69,7 @@ export default function WorkSection() {
       </div>
 
       <h3 className="mb-6 text-[1.15rem] font-semibold text-white md:text-[1.35rem]">Experiments &amp; Tools</h3>
-      <article className={`${styles.projectCard} group relative cursor-pointer`}>
-        <a
-          href={leadExperimentPrimaryUrl}
-          className="absolute inset-0 z-10 rounded-[20px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-purple)] focus-visible:outline-offset-[-3px]"
-          aria-label={`Open ${leadExperiment.title}`}
-          target="_blank"
-          rel="noreferrer"
-        ></a>
-
-        <div className="relative z-0">
-          <span
-            className="mb-4 inline-block rounded border px-[10px] py-1 text-xs font-bold uppercase tracking-[0.1em]"
-            style={leadExperimentAccent.badge}
-          >
-            {leadExperiment.label}
-          </span>
-          <h4 className="mb-4 text-[2rem] text-white md:text-[2.5rem]">{leadExperiment.title}</h4>
-          <p className="mb-10 max-w-[650px] text-base text-[var(--text-muted)] md:text-[1.15rem]">
-            {leadExperiment.description}
-          </p>
-
-          <div className="flex flex-wrap items-center gap-5">
-            <span className="inline-flex items-center gap-[10px] rounded-[30px] bg-[rgba(255,255,255,0.1)] px-6 py-3 font-semibold text-white transition-all duration-300 group-hover:translate-x-[5px] group-hover:bg-[var(--accent-purple)] group-hover:text-black">
-              {leadExperiment.siteUrl ? "Visit Site" : "View Source"}
-            </span>
-            {leadExperiment.siteUrl ? (
-              <a
-                href={leadExperiment.repositoryUrl}
-                className="relative z-20 border-b border-[var(--accent-purple)] pb-[2px] text-[0.9rem] text-white"
-                target="_blank"
-                rel="noreferrer"
-              >
-                GitHub
-              </a>
-            ) : null}
-          </div>
-        </div>
-      </article>
+      <FeaturedProjectCard project={leadExperiment} headingLevel="h4" />
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-[repeat(auto-fit,minmax(280px,1fr))] md:gap-8">
         {supportingExperiments.map((project) => {

--- a/src/components/WorkSection.tsx
+++ b/src/components/WorkSection.tsx
@@ -12,6 +12,9 @@ export default function WorkSection() {
   const [flagship, ...supportingSelectedWork] = selectedWork;
   const flagshipAccent = getProjectAccentStyles(flagship.accentColour);
   const flagshipPrimaryUrl = getPrimaryProjectUrl(flagship);
+  const [leadExperiment, ...supportingExperiments] = experiments;
+  const leadExperimentAccent = getProjectAccentStyles(leadExperiment.accentColour);
+  const leadExperimentPrimaryUrl = getPrimaryProjectUrl(leadExperiment);
 
   return (
     <section id="work" className="py-16 md:py-20">
@@ -107,8 +110,47 @@ export default function WorkSection() {
       </div>
 
       <h3 className="mb-6 text-[1.15rem] font-semibold text-white md:text-[1.35rem]">Experiments &amp; Tools</h3>
+      <article className={`${styles.projectCard} group relative cursor-pointer`}>
+        <a
+          href={leadExperimentPrimaryUrl}
+          className="absolute inset-0 z-10 rounded-[20px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--accent-purple)] focus-visible:outline-offset-[-3px]"
+          aria-label={`Open ${leadExperiment.title}`}
+          target="_blank"
+          rel="noreferrer"
+        ></a>
+
+        <div className="relative z-0">
+          <span
+            className="mb-4 inline-block rounded border px-[10px] py-1 text-xs font-bold uppercase tracking-[0.1em]"
+            style={leadExperimentAccent.badge}
+          >
+            {leadExperiment.label}
+          </span>
+          <h4 className="mb-4 text-[2rem] text-white md:text-[2.5rem]">{leadExperiment.title}</h4>
+          <p className="mb-10 max-w-[650px] text-base text-[var(--text-muted)] md:text-[1.15rem]">
+            {leadExperiment.description}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-5">
+            <span className="inline-flex items-center gap-[10px] rounded-[30px] bg-[rgba(255,255,255,0.1)] px-6 py-3 font-semibold text-white transition-all duration-300 group-hover:translate-x-[5px] group-hover:bg-[var(--accent-purple)] group-hover:text-black">
+              {leadExperiment.siteUrl ? "Visit Site" : "View Source"}
+            </span>
+            {leadExperiment.siteUrl ? (
+              <a
+                href={leadExperiment.repositoryUrl}
+                className="relative z-20 border-b border-[var(--accent-purple)] pb-[2px] text-[0.9rem] text-white"
+                target="_blank"
+                rel="noreferrer"
+              >
+                GitHub
+              </a>
+            ) : null}
+          </div>
+        </div>
+      </article>
+
       <div className="grid grid-cols-1 gap-6 md:grid-cols-[repeat(auto-fit,minmax(280px,1fr))] md:gap-8">
-        {experiments.map((project) => {
+        {supportingExperiments.map((project) => {
           const accent = getProjectAccentStyles(project.accentColour);
           const primaryUrl = getPrimaryProjectUrl(project);
 

--- a/src/components/work-section-data.ts
+++ b/src/components/work-section-data.ts
@@ -60,6 +60,14 @@ export const experiments: ProjectCard[] = [
     siteUrl: "https://smdu.liminalhq.ca/",
   },
   {
+    label: "Linux Utility",
+    accentColour: "var(--accent-blue)",
+    title: "Emoji Nook",
+    description:
+      "Native Linux emoji picker built with Tauri and React. Launch it from a shortcut, search fast, and drop emoji into the app you were already using.",
+    repositoryUrl: "https://github.com/liminal-hq/emoji-nook",
+  },
+  {
     label: "Knowledge Tooling",
     accentColour: "var(--accent-orange)",
     title: "Coherence Chat Exporter",


### PR DESCRIPTION
## Summary
- feature `SMDU` as the lead card in `Experiments & Tools`
- keep `Emoji Nook`, `Coherence Chat Exporter`, and `Keep Note Converter` in the supporting grid
- sync the README project list with the site content

## Testing
- `pnpm lint`
- `pnpm test`
